### PR TITLE
Lock Werkzeug to version 2.3.8

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ Flask-SQLAlchemy==3.0.3
 psycopg2-binary==2.9.5
 celery==5.2.7
 redis==4.5.1
+Werkzeug==2.3.8


### PR DESCRIPTION
This fixes the error "ImportError: cannot import name 'url_quote' from 'werkzeug.urls'" by pinning Werkzeug to version 2.3.8.

The underlying cause of this error is that Flask specifies Werkzeug>=2.2.0 as a dependency, resulting in new builds using Werkzeug version 3.*, which contained breaking changes.